### PR TITLE
change many e-mail separator

### DIFF
--- a/src/Kunstmaan/FormBundle/Helper/FormMailer.php
+++ b/src/Kunstmaan/FormBundle/Helper/FormMailer.php
@@ -44,7 +44,7 @@ class FormMailer implements FormMailerInterface
     {
         $request = $this->container->get('request_stack')->getCurrentRequest();
 
-        $toArr = explode("\r\n", $to);
+        $toArr = explode(",", $to);
 
         $message = (new Swift_Message($subject))
             ->setFrom($from)


### PR DESCRIPTION
As in KunstmaanBundlesCMS/src/Kunstmaan/FormBundle/Form/AbstractFormPageAdminType.php the type of the to_email field (line 38) can't contain \r\n (because it's a simple textType, no eol can't be entered in the backend), rather use comma as e-mail separator.

Other possibility is changing field to_email to use a TextareaType::class and keep \r\n.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | maybe

